### PR TITLE
Dropdown menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,22 @@ gem 'active_bootstrap_skin'
 
 - In the `active_admin.scss` file, you include `active_bootstrap_skin`. **Note: You have to comment the active admin stylesheets.**
 
-```
+```css
 // Active Admin's got SASS!
 // @import "active_admin/mixins";
 // @import "active_admin/base";
 
 // Active Bootstrap
 @import "active_bootstrap_skin";
+```
+
+- In the `active_admin.js` file, you require `active_bootstrap_skin`.
+
+```javascript
+//= require active_admin/base
+//= require bootstrap-sprockets
+
+//= require active_bootstrap_skin
 ```
 
 ## Screens

--- a/app/assets/javascripts/active_bootstrap_skin.js
+++ b/app/assets/javascripts/active_bootstrap_skin.js
@@ -1,0 +1,28 @@
+$(document).ready(function() {
+  // Add meta view port
+  $('head').append('<meta name="viewport" content="width=device-width, initial-scale=1">');
+
+  // Dropdown menus
+  $(window).resize(function(){
+    if ($(window).width() <= 768) {
+      $('#tabs').addClass('collapse');
+    } else {
+      $('#tabs').removeClass('collapse');
+    }
+  });
+
+  html_responsive = ' \
+    <ul class="header-item tabs mobile"> \
+      <li> \
+        <button class="navbar-toggle button_mobile_burger" type="button" data-toggle="collapse" href="#tabs" aria-expanded="true" aria-controls="tabs"> \
+          <span class="sr-only">Toggle navigation</span> \
+          <span class="icon-bar"></span> \
+          <span class="icon-bar"></span> \
+          <span class="icon-bar"></span> \
+        </button> \
+      </li> \
+    </ul> \
+  '
+
+  $(html_responsive).insertAfter('#site_title');
+});

--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -2,6 +2,12 @@
 
 #wrapper {
   @extend .container-fluid;
+  padding-left: 0px;
+  padding-right: 0px;
+  div {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
 }
 
 .flash {
@@ -14,7 +20,7 @@
 }
 
 .flash_notice {
-  @extend .alert-success;
+  @extend .alert-success
 }
 
 #error_explanation {
@@ -49,10 +55,31 @@
 #header {
   @extend .navbar;
   @extend .navbar-inverse;
+  border-radius: 0px;
+
+  .mobile {
+    display: none;
+  }
 
   @media (max-width: 768px) {
+    .button_mobile_burger {
+      margin-top: 0;
+    }
+
     #site_title {
-      float: none;
+      float: left;
+    }
+
+    #utility_nav {
+      display: none;
+    }
+
+    #tabs {
+      clear: both;
+    }
+
+    .mobile {
+      display: block;
     }
 
     .header-item.tabs {
@@ -81,9 +108,7 @@
     @extend .nav;
     @extend .navbar-nav;
 
-    li.current {
-      @extend .active;
-    }
+    li.current { @extend .active; }
   }
 
 
@@ -114,19 +139,12 @@
   .filter_form_field {
     @extend .form-group;
 
-    input,select {
-      @extend .form-control;
-    }
+    input,select { @extend .form-control; }
   }
 
   .buttons {
-    input, a {
-      @extend .btn;
-      @extend .btn-default;
-    }
-    input[type="submit"] {
-      @extend .btn-primary;
-    }
+    input, a { @extend .btn; @extend .btn-default; }
+    input[type="submit"] { @extend .btn-primary; }
   }
 }
 
@@ -135,17 +153,13 @@
   @extend .row;
 
   &.without_sidebar {
-    #main_content_wrapper {
-      @extend .col-lg-6;
-    }
+    #main_content_wrapper { @extend .col-md-6; }
   }
 
   &.with_sidebar {
-    #main_content_wrapper {
-       @extend .col-lg-9;
-    }
+    #main_content_wrapper { @extend .col-md-9; }
     #sidebar {
-      @extend .col-lg-3;
+      @extend .col-md-3;
       input {
         margin-top: 10px;
       }
@@ -183,11 +197,11 @@
   }
 
   .ui-datepicker-prev {
-    @extend .pull-left;
+    float: left;
   }
 
   .ui-datepicker-next {
-    @extend .pull-right;
+    float: right;
   }
 
   .ui-datepicker-today {
@@ -201,15 +215,14 @@
 }
 
 /* Tables */
-.index_table {
-  @extend .table;
-}
-.attributes_table table {
-  @extend .table;
-}
+.index_as_table { @extend .table-responsive; }
+.index_table      { @extend .table; }
+.attributes_table table { @extend .table; }
 
 /* Forms */
 form {
+  //@extend form[role="form"];
+
   .inputs, .actions {
     ol {
       padding-left: 0;
@@ -239,6 +252,7 @@ form {
   }
 
   label.label {
+    /* The label class has a different meaning in bootstrap */
     display: inline-block;
     font-weight: bold;
 

--- a/lib/active_bootstrap_skin/version.rb
+++ b/lib/active_bootstrap_skin/version.rb
@@ -1,3 +1,3 @@
 module ActiveBootstrapSkin
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Solve issue #4 
- Add meta viewport tag to control layout on mobile browsers
- Support drop-down menus

<img width="1276" alt="dashboard___example" src="https://cloud.githubusercontent.com/assets/1997137/15280259/d47272f4-1b58-11e6-86e8-b35836557890.png">

<img width="1276" alt="dashboard___example" src="https://cloud.githubusercontent.com/assets/1997137/15280303/57980aea-1b59-11e6-9cda-b58573a03f84.png">
