### PR TITLE
Remove Padding 5px for all div under #wrapper

### DIFF
--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -4,10 +4,6 @@
   @extend .container-fluid;
   padding-left: 0px;
   padding-right: 0px;
-  div {
-    padding-left: 5px;
-    padding-right: 5px;
-  }
 }
 
 .flash {


### PR DESCRIPTION
As discussed on issue #10 : setting a different padding to all div under `#wrapper` breaks the Bootstrap Grid.

The default 15px padding can be changed using the sass/less variable `grid-gutter-width`
