### PR TITLE
Improve layout of forms

### DIFF
--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -273,3 +273,19 @@ form {
     border-radius: inherit;
   }
 }
+
+/* Display of checkboxes and radios */
+
+.check_boxes {
+  @extend .checkbox;
+}
+
+.check_boxes, .radio {
+  label {
+    font-weight: normal;
+  }
+
+  legend label {
+    padding: 0;
+  }
+}

--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -274,6 +274,13 @@ form {
   }
 }
 
+legend.label {
+  @extend legend;
+  text-align: left;
+  border-radius: 0;
+  margin-bottom: 10px;
+}
+
 /* Display of checkboxes and radios */
 
 .check_boxes {


### PR DESCRIPTION
* Improve layout and readability of checkboxes and radios
** save vertical space
** align with typical bootstrap look
*** http://getbootstrap.com/docs/4.1/components/forms/#default-stacked
** font-weight normal gives better readability
*** especially for bigger input groups
* Make legend.label visible
** used to be white text on white background