### PR TITLE
Fix Sass deprecation warning

### DIFF
--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -523,7 +523,8 @@ legend.label {
     }
 
     &.selected {
-      @extend .btn-default.active;
+      @extend .btn-default;
+      @extend .active;
     }
   }
 }


### PR DESCRIPTION
Extending a compound selector, .btn-default.active, is deprecated and will not be supported in a future release.
Consider "@extend .btn-default, .active" instead.
See https://github.com/sass/sass/issues/1599 for details.