### PR TITLE
Set height to "auto" for multiple select elements

### DIFF
--- a/app/assets/stylesheets/active_bootstrap_skin.scss
+++ b/app/assets/stylesheets/active_bootstrap_skin.scss
@@ -213,6 +213,10 @@
     @extend .form-group;
 
     input,select { @extend .form-control; }
+
+    select[multiple] {
+      height: auto;
+    }
   }
 
   .buttons {
@@ -379,6 +383,10 @@ form {
       @extend .form-group;
 
       input,select,textarea { @extend .form-control; }
+
+      select[multiple] {
+        height: auto;
+      }
     }
   }
 


### PR DESCRIPTION
Override fixed height inherited from bootstrap's .form-control class

- otherwise options become partially obscured
- height should be set individually via the size attribute